### PR TITLE
Fix ProfileController model imports

### DIFF
--- a/api/server/controllers/ProfileController.js
+++ b/api/server/controllers/ProfileController.js
@@ -1,10 +1,12 @@
 // ProfileController.js
 // Aggregates user info and usage stats for profile dialog
 
-const User = require('~/models/User');
-const Conversation = require('~/models/schema/convoSchema');
-const Message = require('~/models/schema/messageSchema');
-const { Transaction } = require('~/models/Transaction'); // <-- Correctly import the Mongoose model
+const {
+  User,
+  Conversation,
+  Message,
+  Transaction,
+} = require('~/db/models');
 const { logger } = require('~/config');
 
 /**


### PR DESCRIPTION
## Summary
- fix ProfileController model imports after schema changes

## Testing
- `npm run test:api` *(fails: Cannot find module 'librechat-data-provider')*

------
https://chatgpt.com/codex/tasks/task_b_684abf8d77b4832eb4cc5b9da4b3825f