### PR TITLE
Fix availableTools caching

### DIFF
--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -97,6 +97,7 @@ const AppService = async (app) => {
         await mcpManager.mapAvailableTools(newTools);
         availableToolsCache = newTools;
         lastToolsRefresh = now;
+        app.locals.availableTools = availableToolsCache;
       }
     }
     return availableToolsCache;
@@ -116,6 +117,7 @@ const AppService = async (app) => {
     socialLogins,
     filteredTools,
     includedTools,
+    availableTools: availableToolsCache,
     imageOutputType,
     interfaceConfig,
     turnstileConfig,
@@ -129,6 +131,7 @@ const AppService = async (app) => {
       ...defaultLocals,
       [EModelEndpoint.agents]: agentsDefaults,
     };
+    app.locals.availableTools = availableToolsCache;
     return;
   }
 
@@ -186,6 +189,7 @@ const AppService = async (app) => {
     modelSpecs: processModelSpecs(endpoints, config.modelSpecs, interfaceConfig),
     ...endpointLocals,
   };
+  app.locals.availableTools = availableToolsCache;
 };
 
 module.exports = AppService;


### PR DESCRIPTION
## Summary
- update `AppService` to keep `availableTools` in `app.locals`
- refresh cached tools when server cache expires

## Testing
- `npm run test:api` *(fails: Cannot find module 'librechat-data-provider')*

------
https://chatgpt.com/codex/tasks/task_b_684af97271f8832ea3fdf53b02d3b56b