### PR TITLE
Add MCP refresh endpoint

### DIFF
--- a/api/server/controllers/MCPController.js
+++ b/api/server/controllers/MCPController.js
@@ -1,0 +1,39 @@
+const { processMCPEnv } = require('librechat-data-provider');
+const { MCPManager } = require('@librechat/api');
+const { getMCPManager, logger } = require('~/config');
+const { getCustomConfig } = require('~/server/services/Config');
+const { loadAndFormatTools } = require('~/server/services/ToolService');
+
+/**
+ * Reinitializes MCP servers and refreshes available tools
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function reinitializeMCP(req, res) {
+  try {
+    const config = await getCustomConfig();
+    if (!config?.mcpServers) {
+      return res.status(400).json({ message: 'MCP servers not configured' });
+    }
+
+    await MCPManager.destroyInstance();
+    const mcpManager = getMCPManager();
+    await mcpManager.initializeMCP(config.mcpServers, processMCPEnv);
+
+    const { filteredTools = [], includedTools = [], paths } = req.app.locals;
+    const tools = loadAndFormatTools({
+      adminFilter: filteredTools,
+      adminIncluded: includedTools,
+      directory: paths.structuredTools,
+    });
+    await mcpManager.mapAvailableTools(tools);
+    req.app.locals.availableTools = tools;
+
+    res.status(200).json({ message: 'MCP reinitialized' });
+  } catch (error) {
+    logger.error('Failed to reinitialize MCP', error);
+    res.status(500).json({ message: error.message });
+  }
+}
+
+module.exports = { reinitializeMCP };

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -109,6 +109,7 @@ const startServer = async () => {
   app.use('/api/balance', routes.balance);
   app.use('/api/models', routes.models);
   app.use('/api/plugins', routes.plugins);
+  app.use('/api/mcp', routes.mcp);
   app.use('/api/config', routes.config);
   app.use('/api/assistants', routes.assistants);
   app.use('/api/files', await routes.files.initialize());

--- a/api/server/routes/index.js
+++ b/api/server/routes/index.js
@@ -16,6 +16,7 @@ const search = require('./search');
 const models = require('./models');
 const convos = require('./convos');
 const config = require('./config');
+const mcp = require('./mcp');
 const agents = require('./agents');
 const roles = require('./roles');
 const oauth = require('./oauth');
@@ -54,6 +55,7 @@ module.exports = {
   balance,
   messages,
   memories,
+  mcp,
   endpoints,
   tokenizer,
   assistants,

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { reinitializeMCP } = require('~/server/controllers/MCPController');
+
+const router = express.Router();
+
+// No authentication middleware applied
+router.post('/refresh', reinitializeMCP);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add new `reinitializeMCP` controller to reset MCP servers
- expose unauthenticated `/api/mcp/refresh` endpoint
- hook up the route in server

## Testing
- `npm run test:api` *(fails: Cannot find module 'librechat-data-provider'; MongoDB download blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684c6f61e808832ea6e4a1f723c67f82